### PR TITLE
(test) Moves NSS interoperability tests to allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: MODE=interop CLIENT=boring REVISION=origin/master
+    - env: MODE=interop CLIENT=tstclnt REVISION=default ZRTT=1
 
 install:
   - if [ "$MODE" = "interop" ]; then ./_dev/tris-localserver/start.sh -d && docker ps -a; fi


### PR DESCRIPTION
Tests against NSS master branch do not work anymore correctly. Reported
error says:
	1: SSL3[1768679856]: handle alert record
	1: SSL3[1768679856] received alert, level = 2, description = 70
	SSL: destroy sid: sid=0x696c27a0 cached=0
	1: SSL[1768679856]: handshake gathering, rv=-1
	1: SSL[1768679856]: SecureSend: returning -1 count, error -12190
	tstclnt: write to SSL socket failed: SSL_ERROR_PROTOCOL_VERSION_ALERT: Peer reports incompatible or unsupported protocol version.

Not sure what's the root cause of the problem, but as the last commit on
tls-tris has succeeded, the problem/change causing regression must be on
NSS side.
I propose to temporarily allow failures of those tests to keep tls-tris build
regression less.